### PR TITLE
Enable prev & next page icon for Fcitx 5 in input panel

### DIFF
--- a/material/theme.conf
+++ b/material/theme.conf
@@ -28,6 +28,12 @@ Bottom=7
 [InputPanel/Background]
 Image=input.png
 
+[InputPanel/PrevPage]
+Image=prev.png
+
+[InputPanel/NextPage]
+Image=next.png
+
 [InputPanel/Background/Margin]
 Left=14
 Right=14


### PR DESCRIPTION
Somehow I did not notice the missing icons all these years!

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td>

![屏幕截图_20260413_010109](https://github.com/user-attachments/assets/5d95ebd7-5b78-4275-8059-5434523aaceb)

 <td>

![屏幕截图_20260413_010142](https://github.com/user-attachments/assets/f7b6ac22-6786-44b8-a6ec-089f018a2761)

</table>